### PR TITLE
Add vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 
 # Build artifacts
 source/latest
+vendor/
 
 # YARD artifacts
 .yardoc


### PR DESCRIPTION
You can use `bundle` to install Ruby Gems to the project folder instead of globally. That's what I did when building the docs locally.

It creates a directory `vendor/` with the third-party dependencies. We don't need all those showing up in git. 